### PR TITLE
Fix/JWT on option

### DIFF
--- a/shard.lock
+++ b/shard.lock
@@ -70,7 +70,7 @@ shards:
 
   jwt:
     github: crystal-community/jwt
-    version: 0.4.0
+    version: 1.1.0
 
   kilt:
     github: jeromegn/kilt
@@ -91,6 +91,10 @@ shards:
   mysql:
     github: crystal-lang/crystal-mysql
     version: 0.6.0
+
+  openssl_ext:
+    github: stakach/openssl_ext
+    version: 1.0.0
 
   optarg:
     github: mosop/optarg

--- a/src/controllers/session_controller.cr
+++ b/src/controllers/session_controller.cr
@@ -5,7 +5,6 @@ class SessionController < ApplicationController
     if user
       if Crypto::Bcrypt::Password.new(user.password || "") == auth_params[:password]
         session[:current_user_id] = user.id
-        pp session[:current_user_id]
         respond_with do
           json({"token": Auth::JWTService.new.encode({user_id: user.id})}.to_json)
         end

--- a/src/controllers/session_controller.cr
+++ b/src/controllers/session_controller.cr
@@ -5,6 +5,7 @@ class SessionController < ApplicationController
     if user
       if Crypto::Bcrypt::Password.new(user.password || "") == auth_params[:password]
         session[:current_user_id] = user.id
+        pp session[:current_user_id]
         respond_with do
           json({"token": Auth::JWTService.new.encode({user_id: user.id})}.to_json)
         end

--- a/src/pipes/auth.cr
+++ b/src/pipes/auth.cr
@@ -11,13 +11,7 @@ module Pipes
         return missing_JWT(context)
       end
 
-      pp data
-      pp data[0]["user_id"]
-      pp context.session[:current_user_id]
-      pp context.session[:current_user_id].class
-
-      return not_auth(context) if context.session[:current_user_id] != data[0]["user_id"].to_s
-
+      context.session[:current_user_id] = data[0]["user_id"]
       call_next(context)
     end
 

--- a/src/pipes/auth.cr
+++ b/src/pipes/auth.cr
@@ -1,7 +1,7 @@
 module Pipes
   class Auth < Amber::Pipe::Base
     def call(context)
-      call_next(context) if context.request.method == "OPTION"
+      call_next(context) if context.request.method == "OPTIONS"
       begin
         token = context.request.headers["JWT"]
         data = ::Auth::JWTService.new.decode(token)

--- a/src/pipes/auth.cr
+++ b/src/pipes/auth.cr
@@ -12,6 +12,9 @@ module Pipes
       end
 
       pp data
+      pp data[0]["user_id"]
+      pp context.session[:current_user_id]
+      pp context.session[:current_user_id].class
 
       return not_auth(context) if context.session[:current_user_id] != data[0]["user_id"].to_s
 

--- a/src/pipes/auth.cr
+++ b/src/pipes/auth.cr
@@ -11,13 +11,15 @@ module Pipes
         return missing_JWT(context)
       end
 
+      pp data
+
       return not_auth(context) if context.session[:current_user_id] != data[0]["user_id"].to_s
 
       call_next(context)
     end
 
     private def not_auth(context)
-      context.response.status_code = 404
+      context.response.status_code = 403
       error = {errors: ["Please Sign In"]}.to_json
       context.response.print error
     end

--- a/src/pipes/auth.cr
+++ b/src/pipes/auth.cr
@@ -1,11 +1,14 @@
 module Pipes
   class Auth < Amber::Pipe::Base
     def call(context)
+      call_next(context) if context.request.method == "OPTION"
       begin
         token = context.request.headers["JWT"]
         data = ::Auth::JWTService.new.decode(token)
       rescue JWT::VerificationError
         return not_auth(context)
+      rescue KeyError
+        return missing_JWT(context)
       end
 
       return not_auth(context) if context.session[:current_user_id] != data[0]["user_id"].to_s
@@ -15,7 +18,13 @@ module Pipes
 
     private def not_auth(context)
       context.response.status_code = 404
-      error = {error: "Please Sign In"}.to_json
+      error = {errors: ["Please Sign In"]}.to_json
+      context.response.print error
+    end
+
+    private def missing_JWT(context)
+      context.response.status_code = 403
+      error = {errors: ["Missing JWT headers"]}.to_json
       context.response.print error
     end
   end

--- a/src/pipes/auth.cr
+++ b/src/pipes/auth.cr
@@ -1,7 +1,7 @@
 module Pipes
   class Auth < Amber::Pipe::Base
     def call(context)
-      call_next(context) if context.request.method == "OPTIONS"
+      return call_next(context) if context.request.method == "OPTIONS"
       begin
         token = context.request.headers["JWT"]
         data = ::Auth::JWTService.new.decode(token)

--- a/src/services/auth/jwt_service.cr
+++ b/src/services/auth/jwt_service.cr
@@ -2,7 +2,7 @@ require "jwt"
 
 module Auth
   class JWTService
-    def initialize(@algorithm = "HS256", @secret_key = "7QNl8ieiaHwq")
+    def initialize(@algorithm = JWT::Algorithm::HS256, @secret_key = "7QNl8ieiaHwq")
     end
 
     def encode(payload)


### PR DESCRIPTION
- Amélioration : Message d'erreur au bon format quand il manque le header JWT
- Amélioration : Mise à jour de la shard JWT 
- Fix : Les requêtes OPTIONS ne sont plus traitées par le middleware d'authentification
- Régression : Un bug du framework fait que les variables de sessions ne sont pas conservés entre deux requêtes. On réutilise directement l'id du user stocké dans le token JWT plutôt que de vérifier qu'il matche avec la variable de session.