### PR TITLE
Feature/friendships

### DIFF
--- a/.amber.yml
+++ b/.amber.yml
@@ -19,8 +19,8 @@ watch:
       - ./src/**/*.cr
     # exclude: # NOTE simplistic implementation: (1) enumerate all includes and excludes; (2) return (includes - excludes)
     #  - ./src/some_irrelevant_file.cr
-  spec:
-    run_commands:
-      - crystal spec
-    include:
-      - ./spec/**/*.cr
+  # spec:
+  #   run_commands:
+  #     - crystal spec
+  #     include:
+  #       - ./spec/**/*.cr

--- a/config/routes.cr
+++ b/config/routes.cr
@@ -28,6 +28,7 @@ Amber::Server.configure do
     delete "/auth/sign_out", SessionController, :delete
 
     resources "/themes", ThemeController, except: [:new, :edit]
+    resources "/friendships", FriendshipController, only: [:index, :create, :update]
     resources "/themes/:theme_id/medias", MediaController, except: [:new, :edit]
     resources "/medias/:media_id/questions", QuestionController, except: [:new, :edit]
   end

--- a/db/migrations/20190629184942970_create_friendships.sql
+++ b/db/migrations/20190629184942970_create_friendships.sql
@@ -1,0 +1,16 @@
+-- +micrate Up
+-- SQL in section 'Up' is executed when this migration is applied
+CREATE TABLE friendships (
+  id BIGSERIAL PRIMARY KEY,
+  status VARCHAR DEFAULT 'pending',
+  asked_by INTEGER,
+  asked_to INTEGER,
+  created_at TIMESTAMP,
+  updated_at TIMESTAMP
+);
+CREATE INDEX friendships_asked_by_idx ON friendships (asked_by);
+CREATE INDEX friendships_asked_to_idx ON friendships (asked_to);
+
+-- +micrate Down
+-- SQL section 'Down' is executed when this migration is rolled back
+DROP TABLE IF EXISTS friendships;

--- a/shard.lock
+++ b/shard.lock
@@ -10,7 +10,7 @@ shards:
 
   awscr-s3:
     github: taylorfinnell/awscr-s3
-    version: 0.3.4
+    version: 0.4.0
 
   awscr-signer:
     github: taylorfinnell/awscr-signer
@@ -70,7 +70,7 @@ shards:
 
   jwt:
     github: crystal-community/jwt
-    version: 1.1.0
+    version: 1.1.1
 
   kilt:
     github: jeromegn/kilt

--- a/spec/models/friendship_spec.cr
+++ b/spec/models/friendship_spec.cr
@@ -1,0 +1,26 @@
+require "./spec_helper"
+require "../../src/models/friendship.cr"
+
+describe Friendship do
+  Spec.before_each do
+    Friendship.clear
+  end
+
+  describe "validations" do
+    describe "status" do
+      %w(pending accepted rejected).each do |status|
+        describe status do
+          it "is valid" do
+            Friendship.create(status: status).valid?.should eq(true)
+          end
+        end
+      end
+
+      describe "other status" do
+        it "is not valid" do
+          Friendship.create(status: "IDK").valid?.should eq(false)
+        end
+      end
+    end
+  end
+end

--- a/src/controllers/friendship_controller.cr
+++ b/src/controllers/friendship_controller.cr
@@ -1,0 +1,82 @@
+class FriendshipController < ApplicationController
+  INDEX_FINDER = {
+    nil => ->(repo : Query::Friendships) { repo.all },
+    "accepted" => ->(repo : Query::Friendships) { repo.accepted },
+    "pending" => ->(repo : Query::Friendships) { repo.pending }
+  }
+
+  getter friendship = Friendship.new
+
+  before_action do
+    only [:update] { set_friendship }
+  end
+
+  def index
+    if action = INDEX_FINDER[params["status"]?]?
+      repository = Query::Friendships.new(session["current_user_id"].not_nil!)
+
+      respond_with do
+        json action.call(repository).to_json
+      end
+    else
+      respond_with(400) do
+        json({errors: {status: "Unhandled status"}}.to_json)
+      end
+    end
+  end
+
+  def create
+    Factory::Friendship.new(creation_friendship_params.validate!, session["current_user_id"].not_nil!)
+      .build
+      .bind(save_friendship)
+      .fmap(handle_success(201))
+      .value_or(handle_error)
+  end
+
+  def update
+    friendship.set_attributes update_friendship_params.validate!
+    if friendship.save
+      respond_with do
+        json friendship.to_json
+      end
+    else
+      respond_with(403) do
+        json({errors: formatted_errors(friendship)}.to_json)
+      end
+    end
+  end
+
+  private def creation_friendship_params
+    params.validation do
+      required :asked_to
+    end
+  end
+
+  private def update_friendship_params
+    params.validation do
+      required :status
+    end
+  end
+
+  private def set_friendship
+    @friendship = Friendship.find! params[:id]
+  end
+
+  private def save_friendship
+    ->(friendship : Friendship) do
+      if friendship.save
+        Monads::Right.new(friendship)
+      else
+        Monads::Left.new(formatted_errors(friendship))
+      end
+    end
+  end
+
+  private def handle_success(code)
+    ->(friendship : Friendship) do
+      respond_with(code) do
+        json friendship.to_json
+      end
+    end
+  end
+end

--- a/src/controllers/friendship_controller.cr
+++ b/src/controllers/friendship_controller.cr
@@ -1,8 +1,8 @@
 class FriendshipController < ApplicationController
   INDEX_FINDER = {
-    nil => ->(repo : Query::Friendships) { repo.all },
+    nil        => ->(repo : Query::Friendships) { repo.all },
     "accepted" => ->(repo : Query::Friendships) { repo.accepted },
-    "pending" => ->(repo : Query::Friendships) { repo.pending }
+    "pending"  => ->(repo : Query::Friendships) { repo.pending },
   }
 
   getter friendship = Friendship.new

--- a/src/controllers/media_controller.cr
+++ b/src/controllers/media_controller.cr
@@ -68,7 +68,7 @@ class MediaController < ApplicationController
       if media.save
         Monads::Right.new(media)
       else
-        Monads::Left.new(media.errors.map { |error| {error.field.to_s => error.message.to_s} })
+        Monads::Left.new(formatted_errors(media))
       end
     end
   end

--- a/src/models/friendship.cr
+++ b/src/models/friendship.cr
@@ -1,0 +1,14 @@
+class Friendship < Granite::Base
+  adapter pg
+  table_name friendships
+
+  primary id : Int64
+  field status : String
+  field asked_by : Int32
+  field asked_to : Int32
+  timestamps
+
+  validate(:status, "Status should be either 'pending', 'accepted' or 'rejected'", ->(friendship : self) {
+    %w(pending accepted rejected).includes? friendship.status
+  })
+end

--- a/src/services/factory/friendship_factory.cr
+++ b/src/services/factory/friendship_factory.cr
@@ -1,0 +1,22 @@
+require "monads"
+
+module Factory
+  class Friendship
+    def initialize(@params : Hash(String, String | Nil), @current_user : String)
+    end
+
+    def build
+      return Monads::Left.new([{"friendship" => "Friendship already asked"}]) if already_asked?
+      return Monads::Left.new([{"friendship" => "You can't be your own friend"}]) if @current_user == @params["asked_to"]
+
+      friendship = ::Friendship.new @params
+      friendship.asked_by = @current_user.to_i
+      friendship.status = "pending"
+      Monads::Right.new(friendship)
+    end
+
+    private def already_asked?
+      Query::Friendships.new(@current_user).already_asked?(@params["asked_to"].not_nil!)
+    end
+  end
+end

--- a/src/services/query/friendships.cr
+++ b/src/services/query/friendships.cr
@@ -1,0 +1,60 @@
+module Query
+  class Friendships
+    def initialize(@user_id : String)
+    end
+
+    def all
+      exec(select_query)
+    end
+
+    def pending
+      exec(select_query("pending"))
+    end
+
+    def accepted
+      exec(select_query("accepted"))
+    end
+
+    def already_asked?(id)
+      Friendship.scalar asked_query(id), &.to_s.to_i > 0
+    end
+
+    private def exec(select_query)
+      res = Friendship.query(select_query) { |d| d }
+      data = Array(Hash(String, String | Nil)).new
+      res.each do
+        data << {
+          "user_id" => res.read(Int64 | Nil).to_s, "friendship_id" => res.read(Int64 | Nil).to_s,
+          "nickname" => res.read(String | Nil), "status" => res.read(String | Nil)
+        }
+      end
+
+      data
+    end
+
+    private def select_query(status)
+      select_query + select_status(status)
+    end
+
+    private def select_query
+      "SELECT users.id, friendships.id, users.nickname, friendships.status, \
+        friendships.created_at, friendships.updated_at \
+        FROM friendships \
+        LEFT JOIN users \
+        ON (friendships.asked_to = users.id OR friendships.asked_by = users.id) \
+        WHERE (friendships.asked_to = #{@user_id} OR friendships.asked_by = #{@user_id}) \
+        AND users.id != #{@user_id}"
+    end
+
+    private def select_status(status)
+       " AND friendships.status = '#{status}'"
+    end
+
+    private def asked_query(id)
+      "SELECT COUNT(*) FROM friendships \
+        WHERE friendships.status != 'rejected' \
+        AND ((friendships.asked_by = #{@user_id} AND friendships.asked_to = #{id}) \
+        OR (friendships.asked_by = #{id} AND friendships.asked_to = #{@user_id}))"
+    end
+  end
+end

--- a/src/services/query/friendships.cr
+++ b/src/services/query/friendships.cr
@@ -25,7 +25,7 @@ module Query
       res.each do
         data << {
           "user_id" => res.read(Int64 | Nil).to_s, "friendship_id" => res.read(Int64 | Nil).to_s,
-          "nickname" => res.read(String | Nil), "status" => res.read(String | Nil)
+          "nickname" => res.read(String | Nil), "status" => res.read(String | Nil),
         }
       end
 
@@ -47,7 +47,7 @@ module Query
     end
 
     private def select_status(status)
-       " AND friendships.status = '#{status}'"
+      " AND friendships.status = '#{status}'"
     end
 
     private def asked_query(id)


### PR DESCRIPTION
- Nouveau : CRU des friendships
  - Index ```GET  /friendships``` JWT nécessaire
  On peut rajouter un argument pour obtenir les demandes selon un statut : 
  ```GET  /friendships?status=pending```
  Fonctionne avec pending et accepted. Erreur pour tout autre statut.
  - Create ```POST /friendships``` JWT nécessaire
  ```body: {"asked_to": Id de l'autre utilisateur}```
  Erreurs exotiques :
    - Ne peut pas être ami avec soi même
    - Demande d'ami deja envoyée
  Note 1 : On ne verifie pas que les users existent rééellement
  Note 2 : Si la demande d'ami existe mais qu'elle a ete rejetee, pas d'erreur
  Note 3 : Par défaut, le statut est pending
  - Update ```PUT /friendships/:id``` JWT nécessaire
  ```body: {"status": pending ou accepted ou rejected}```
  Erreurs exotiques :
    - Le statut n'est pas dans la liste
  Note 1 : Pour supprimer une demande, il faut la refuser avec une action update

Toutes les reponses ont cette forme
```
{
  "user_id": Id de l'autre utilisateur,
  "nickname":  nickname de l'autre utilisateur,
  "friendship_id": id de la relation,
  "status": pending, accepted ou rejected
}
```

Note : Les requetes index et create se basent sur le token du JWT pour selectionner le user autour duquel tournent les requetes
