### PR TITLE
Feature/Lobby

### DIFF
--- a/config/routes.cr
+++ b/config/routes.cr
@@ -24,13 +24,18 @@ Amber::Server.configure do
   end
 
   routes :api do
+    # User
     resources "/users", UserController, except: [:create, :new, :edit]
     delete "/auth/sign_out", SessionController, :delete
-
-    resources "/themes", ThemeController, except: [:new, :edit]
     resources "/friendships", FriendshipController, only: [:index, :create, :update]
+
+    # Set up
+    resources "/themes", ThemeController, except: [:new, :edit]
     resources "/themes/:theme_id/medias", MediaController, except: [:new, :edit]
     resources "/medias/:media_id/questions", QuestionController, except: [:new, :edit]
+
+    # Game
+    resources "/lobbies", LobbyController, except: [:new, :edit, :update]
   end
 
   routes :public_api do

--- a/config/routes.cr
+++ b/config/routes.cr
@@ -36,6 +36,7 @@ Amber::Server.configure do
 
     # Game
     resources "/lobbies", LobbyController, except: [:new, :edit, :update]
+    resources "/lobbies/:id/join", LobbySessionController, only: [:create]
   end
 
   routes :public_api do

--- a/db/migrations/20190630221306988_create_lobby.sql
+++ b/db/migrations/20190630221306988_create_lobby.sql
@@ -1,0 +1,14 @@
+-- +micrate Up
+-- SQL in section 'Up' is executed when this migration is applied
+CREATE TABLE lobbies (
+  id BIGSERIAL PRIMARY KEY,
+  restricted BOOLEAN,
+  theme_id INTEGER,
+  created_at TIMESTAMP,
+  updated_at TIMESTAMP
+);
+CREATE INDEX lobby_theme_id_idx ON lobbies (theme_id);
+
+-- +micrate Down
+-- SQL section 'Down' is executed when this migration is rolled back
+DROP TABLE IF EXISTS lobbies;

--- a/db/migrations/20190630221306988_create_lobby.sql
+++ b/db/migrations/20190630221306988_create_lobby.sql
@@ -3,11 +3,15 @@
 CREATE TABLE lobbies (
   id BIGSERIAL PRIMARY KEY,
   restricted BOOLEAN,
+  active BOOLEAN,
   theme_id INTEGER,
+  created_by INTEGER,
+  questions INTEGER,
   created_at TIMESTAMP,
   updated_at TIMESTAMP
 );
 CREATE INDEX lobby_theme_id_idx ON lobbies (theme_id);
+CREATE INDEX lobby_created_by_idx ON lobbies (created_by);
 
 -- +micrate Down
 -- SQL section 'Down' is executed when this migration is rolled back

--- a/db/migrations/20190707150945155_add_status_and_rank_to_user.sql
+++ b/db/migrations/20190707150945155_add_status_and_rank_to_user.sql
@@ -1,0 +1,11 @@
+-- +micrate Up
+-- SQL in section 'Up' is executed when this migration is applied
+ALTER TABLE users
+  ADD status VARCHAR DEFAULT 'online',
+  ADD rank VARCHAR DEFAULT 'user';
+
+-- +micrate Down
+-- SQL section 'Down' is executed when this migration is rolled back
+ALTER TABLE users
+  DROP COLUMN status,
+  DROP COLUMN rank;

--- a/db/migrations/20190707175905680_user_can_join_a_channel.sql
+++ b/db/migrations/20190707175905680_user_can_join_a_channel.sql
@@ -1,0 +1,11 @@
+-- +micrate Up
+-- SQL in section 'Up' is executed when this migration is applied
+ALTER TABLE users ADD lobby_id INTEGER;
+CREATE INDEX user_lobby_id_idx ON users (lobby_id);
+
+ALTER TABLE lobbies ADD private_key VARCHAR;
+
+-- +micrate Down
+-- SQL section 'Down' is executed when this migration is rolled back
+ALTER TABLE users DROP COLUMN lobby_id;
+ALTER TABLE lobbies DROP COLUMN private_key;

--- a/spec/controllers/lobby_controller_spec.cr
+++ b/spec/controllers/lobby_controller_spec.cr
@@ -1,0 +1,78 @@
+require "./spec_helper"
+
+def lobby_params(lobby_hash : Hash(Symbol, String))
+  params = [] of String
+  lobby_hash.each do |key, value|
+    params << "#{key}=#{value}"
+  end
+  params.join("&")
+end
+
+class LobbyControllerTest < GarnetSpec::Controller::Test
+  getter handler : Amber::Pipe::Pipeline
+
+  def initialize
+    @handler = Amber::Pipe::Pipeline.new
+    @handler.build :api do
+      plug Amber::Pipe::Error.new
+    end
+    @handler.prepare_pipelines
+  end
+end
+
+describe LobbyControllerTest do
+  Spec.before_each do
+    Lobby.clear
+    Theme.clear
+  end
+
+  subject = LobbyControllerTest.new
+
+  describe "#index" do
+    it "shows lobbies of a theme" do
+      theme1 = Theme.create(title: "theme 1")
+      theme2 = Theme.create(title: "theme 2")
+      lobby1 = Lobby.create(theme_id: theme1.id, restricted: false, questions: 5, active: true)
+      lobby2 = Lobby.create(theme_id: theme2.id, restricted: true, questions: 10, active: true)
+      lobby3 = Lobby.create(theme_id: theme1.id, restricted: false, questions: 5, active: false)
+      response = subject.get "/lobbies"
+
+      response.status_code.should eq(200)
+      response.body.should contain([lobby1].to_json)
+    end
+  end
+
+  describe "#show" do
+    it "shows a lobby" do
+      theme = Theme.create(title: "qwekjh")
+      lobby = Lobby.create(theme_id: theme.id, restricted: true, questions: 10)
+      response = subject.get "/lobbies/#{lobby.id}"
+
+      response.status_code.should eq(200)
+      response.body.should contain(lobby.to_json)
+    end
+  end
+
+  describe "#create" do
+    it "create a lobby" do
+      theme = Theme.create(title: "qwekjh")
+      params = {:theme_id => theme.id.to_s, :restricted => "true", :questions => "10"}
+      response = subject.post "/lobbies", body: lobby_params(params)
+
+      response.status_code.should eq(201)
+      json = JSON.parse(response.body)
+      (json["theme_id"]).should eq(theme.id)
+      (json["questions"]).should eq(10)
+      (json["restricted"]).should eq(true)
+    end
+  end
+
+  describe "#delete" do
+    it "deletes a lobby" do
+      lobby = Lobby.create(active: true, restricted: false, questions: 10)
+      response = subject.delete "/lobbies/#{lobby.id}"
+
+      response.status_code.should eq(204)
+    end
+  end
+end

--- a/spec/controllers/lobby_controller_spec.cr
+++ b/spec/controllers/lobby_controller_spec.cr
@@ -56,14 +56,30 @@ describe LobbyControllerTest do
   describe "#create" do
     it "create a lobby" do
       theme = Theme.create(title: "qwekjh")
-      params = {:theme_id => theme.id.to_s, :restricted => "true", :questions => "10"}
+      params = {:theme_id => theme.id.to_s, :restricted => "false", :questions => "10"}
       response = subject.post "/lobbies", body: lobby_params(params)
 
       response.status_code.should eq(201)
       json = JSON.parse(response.body)
       (json["theme_id"]).should eq(theme.id)
       (json["questions"]).should eq(10)
-      (json["restricted"]).should eq(true)
+      (json["restricted"]).should eq(false)
+      (json["private_key"]?).should eq(nil)
+    end
+
+    describe "when restricted is true" do
+      it "sets a private key" do
+        theme = Theme.create(title: "qwekjh")
+        params = {:theme_id => theme.id.to_s, :restricted => "true", :questions => "10"}
+        response = subject.post "/lobbies", body: lobby_params(params)
+
+        response.status_code.should eq(201)
+        json = JSON.parse(response.body)
+        (json["theme_id"]).should eq(theme.id)
+        (json["questions"]).should eq(10)
+        (json["restricted"]).should eq(true)
+        (json["private_key"]?).should_not eq(nil)
+      end
     end
   end
 

--- a/spec/models/lobby_spec.cr
+++ b/spec/models/lobby_spec.cr
@@ -1,0 +1,18 @@
+require "./spec_helper"
+require "../../src/models/lobby.cr"
+
+describe Lobby do
+  Spec.before_each do
+    Lobby.clear
+  end
+
+  describe "relations" do
+    it "belongs to a theme" do
+      theme = Theme.create(title: "Theme title")
+      lobby = Lobby.create(restricted: false, theme_id: theme.id)
+
+      lobby.theme.class.should eq(Theme)
+      lobby.theme.title.should eq("Theme title")
+    end
+  end
+end

--- a/spec/models/theme_spec.cr
+++ b/spec/models/theme_spec.cr
@@ -15,6 +15,14 @@ describe Theme do
       theme.medias.map(&.id).should eq([media_1.id, media_2.id])
     end
 
+    it "has many lobbies" do
+      theme = Theme.create(title: "theme title", description: "description")
+      lobby_1 = Lobby.create(restricted: true, theme_id: theme.id)
+      lobby_2 = Lobby.create(restricted: false, theme_id: theme.id)
+
+      theme.lobbies.map(&.id).should eq([lobby_1.id, lobby_2.id])
+    end
+
     it "belongs to a user" do
       user = User.create(email: "test@test.fr")
       theme = Theme.create(title: "theme title", description: "description", user_id: user.id)

--- a/src/controllers/lobby_controller.cr
+++ b/src/controllers/lobby_controller.cr
@@ -1,0 +1,60 @@
+class LobbyController < ApplicationController
+  getter lobby = Lobby.new
+
+  before_action do
+    only [:show, :destroy] { set_lobby }
+  end
+
+  def index
+    lobbies = Lobby.where(restricted: false, active: true).select
+    respond_with do
+      json lobbies.to_json
+    end
+  end
+
+  def show
+    respond_with do
+      json lobby.to_json
+    end
+  end
+
+  def create
+    lobby = Lobby.new(creation_lobby_params.validate!)
+    lobby.created_by = session["current_user_id"].try(&.to_i)
+    lobby.active = true
+    if lobby.save
+      respond_with(201) do
+        json lobby.to_json
+      end
+    else
+      respond_with(403) do
+        json({errors: formatted_errors(lobby)}.to_json)
+      end
+    end
+  end
+
+  def destroy
+    lobby.active = false
+    if lobby.save
+      respond_with(204) do
+        json ""
+      end
+    else
+      respond_with(403) do
+        json({errors: formatted_errors(lobby)}.to_json)
+      end
+    end
+  end
+
+  private def creation_lobby_params
+    params.validation do
+      required :theme_id
+      required :questions
+      required :restricted
+    end
+  end
+
+  private def set_lobby
+    @lobby = Lobby.find! params[:id]
+  end
+end

--- a/src/controllers/lobby_session_controller.cr
+++ b/src/controllers/lobby_session_controller.cr
@@ -1,0 +1,26 @@
+class LobbySessionController < ApplicationController
+  getter lobby = Lobby.new
+  getter user = User.new
+
+  before_action do
+    only [:create] { set_lobby }
+  end
+
+  def create
+    if lobby.restricted && (!params["private_key"]? || params["private_key"] != lobby.private_key)
+      respond_with(403) do
+        json({errors: {private_key: "Wrong private key"}}.to_json)
+      end
+    else
+      user.update lobby_id: lobby.id
+      respond_with do
+        json(user.to_json)
+      end
+    end
+  end
+
+  private def set_lobby
+    @lobby = Lobby.find! params[:id]
+    @user = User.find! session["current_user_id"]
+  end
+end

--- a/src/controllers/user_controller.cr
+++ b/src/controllers/user_controller.cr
@@ -51,6 +51,7 @@ class UserController < ApplicationController
       required :password_confirmation
       required :email { |p| p.email? }
       required :nickname
+      optional :rank
     end
   end
 
@@ -58,6 +59,7 @@ class UserController < ApplicationController
     params.validation do
       optional :email { |p| p.email? }
       optional :nickname
+      optional :status
     end
   end
 

--- a/src/controllers/user_controller.cr
+++ b/src/controllers/user_controller.cr
@@ -51,7 +51,6 @@ class UserController < ApplicationController
       required :password_confirmation
       required :email { |p| p.email? }
       required :nickname
-      optional :rank
     end
   end
 
@@ -60,6 +59,7 @@ class UserController < ApplicationController
       optional :email { |p| p.email? }
       optional :nickname
       optional :status
+      optional :rank
     end
   end
 

--- a/src/models/lobby.cr
+++ b/src/models/lobby.cr
@@ -1,0 +1,10 @@
+class Lobby < Granite::Base
+  adapter pg
+  table_name lobbies
+
+  primary id : Int64
+  field restricted : Bool
+  timestamps
+
+  belongs_to :theme, foreign_key: theme_id : Int32
+end

--- a/src/models/lobby.cr
+++ b/src/models/lobby.cr
@@ -6,6 +6,7 @@ class Lobby < Granite::Base
   field restricted : Bool
   field active : Bool
   field questions : Int32
+  field private_key : String
   timestamps
 
   belongs_to :theme, foreign_key: theme_id : Int32

--- a/src/models/lobby.cr
+++ b/src/models/lobby.cr
@@ -4,7 +4,10 @@ class Lobby < Granite::Base
 
   primary id : Int64
   field restricted : Bool
+  field active : Bool
+  field questions : Int32
   timestamps
 
   belongs_to :theme, foreign_key: theme_id : Int32
+  belongs_to :user, foreign_key: created_by : Int32
 end

--- a/src/models/theme.cr
+++ b/src/models/theme.cr
@@ -9,4 +9,5 @@ class Theme < Granite::Base
 
   belongs_to :user, foreign_key: user_id : Int32
   has_many medias : Media
+  has_many lobbies : Lobby
 end

--- a/src/models/user.cr
+++ b/src/models/user.cr
@@ -6,7 +6,11 @@ class User < Granite::Base
   field password : String
   field email : String
   field nickname : String
+  field status : String
+  field rank : String
   timestamps
+
+  before_create :default_values
 
   validate(:email, "Email already in use", ->(user : self) {
     Validation::Uniqueness.new(user, "email").valid?
@@ -15,4 +19,17 @@ class User < Granite::Base
   validate(:nickname, "Nickname already in use", ->(user : self) {
     Validation::Uniqueness.new(user, "nickname").valid?
   })
+
+  validate(:status, "Status should be either 'online', 'offline' or 'afk'", ->(user : self) {
+    (user.new_record? && user.status == nil) || %w(online offline afk).includes? user.status
+  })
+
+  validate(:rank, "Rank should be either 'user' or 'admin'", ->(user : self) {
+    (user.new_record? && user.rank == nil) || %w(admin user).includes? user.status
+  })
+
+  def default_values
+    @rank = "user" if rank == nil
+    @status = "online" if status == nil
+  end
 end

--- a/src/models/user.cr
+++ b/src/models/user.cr
@@ -10,6 +10,8 @@ class User < Granite::Base
   field rank : String
   timestamps
 
+  belongs_to :lobby, foreign_key: lobby_id : Int32
+
   before_create :default_values
 
   validate(:email, "Email already in use", ->(user : self) {

--- a/src/services/factory/lobby_factory.cr
+++ b/src/services/factory/lobby_factory.cr
@@ -1,0 +1,16 @@
+require "monads"
+
+module Factory
+  class Lobby
+    def initialize(@params : Hash(String, String | Nil), @user_id : String | Nil)
+    end
+
+    def build
+      lobby = ::Lobby.new(@params)
+      lobby.created_by = @user_id.try(&.to_i)
+      lobby.private_key = Random::Secure.hex(6) if lobby.restricted
+      lobby.active = true
+      Monads::Right.new(lobby)
+    end
+  end
+end


### PR DESCRIPTION
- Nouveau : CRD des channels
  - Index ```GET  /lobbies``` JWT nécessaire
  Note : N'affiche que les channels publiques actifs
  - Show ```GET  /lobbies/:id``` JWT nécessaire
  - Create ```POST /lobbies``` JWT nécessaire
  ```body: {"theme_id": Id du theme, "questions": nombre de questions d'une partie, "restricted": true si le channel est privé, false s'il est public}```
  Le nouveau channel est créé par le user du JWT
  Si ```restricted``` est à true, le serveur va retourner un element ```private_key``` pour empêcher n'importe qui de rejoindre le channel.
  - Destroy ```DELETE /lobbies/:id``` JWT nécessaire
  Note : le channel n'est pas supprimé en base, mais il est rendu inactif
- Nouveau : C pour rejoindre un channel
  - create ```POST /lobbies/:id/join``` JWT nécessaire
  Note : Pour rejoindre un channel restricted, il faut fournir la clé d'accès
  ```body: {"private_key": clé d'accès}```
- Amélioration : Ajout d'un champ status et rank sur users
  - rank : user ou admin. Valeur par défaut : user
  - status : online, afk, offline. Valeur par defaut : online
  Note : Ces champs ne peuvent pas être remplis sur create (valeurs par défaut), mais etre modifiés sur update
