### PR TITLE
Force content type header

### DIFF
--- a/config/routes.cr
+++ b/config/routes.cr
@@ -4,9 +4,8 @@ Amber::Server.configure do
     plug Amber::Pipe::Error.new
     plug Amber::Pipe::Logger.new
     plug Amber::Pipe::Session.new
-    plug Pipes::CORS.new
+    plug Pipes::CORS.new(methods: %w(POST PUT PATCH DELETE GET))
     plug Pipes::Auth.new
-    plug Amber::Pipe::CORS.new(methods: %w(POST PUT PATCH DELETE GET))
   end
 
   pipeline :public_api do
@@ -14,7 +13,7 @@ Amber::Server.configure do
     plug Amber::Pipe::Error.new
     plug Amber::Pipe::Logger.new
     plug Amber::Pipe::Session.new
-    plug Amber::Pipe::CORS.new(methods: %w(POST PUT PATCH DELETE GET))
+    plug Pipes::CORS.new(methods: %w(POST PUT PATCH DELETE GET))
   end
 
   # All static content will run these transformations

--- a/config/routes.cr
+++ b/config/routes.cr
@@ -4,6 +4,7 @@ Amber::Server.configure do
     plug Amber::Pipe::Error.new
     plug Amber::Pipe::Logger.new
     plug Amber::Pipe::Session.new
+    plug Pipes::CORS.new
     plug Pipes::Auth.new
     plug Amber::Pipe::CORS.new(methods: %w(POST PUT PATCH DELETE GET))
   end

--- a/src/pipes/auth.cr
+++ b/src/pipes/auth.cr
@@ -1,6 +1,10 @@
 module Pipes
   class Auth < Amber::Pipe::Base
     def call(context)
+      if context.request.method == "OPTIONS"
+        context.request.headers["Access-Control-Request-Headers"] = "content-type,jwt"
+      end
+
       return call_next(context) if context.request.method == "OPTIONS"
       begin
         token = context.request.headers["JWT"]

--- a/src/pipes/auth.cr
+++ b/src/pipes/auth.cr
@@ -1,11 +1,8 @@
 module Pipes
   class Auth < Amber::Pipe::Base
     def call(context)
-      if context.request.method == "OPTIONS"
-        context.request.headers["Access-Control-Request-Headers"] = "content-type,jwt"
-      end
-
       return call_next(context) if context.request.method == "OPTIONS"
+
       begin
         token = context.request.headers["JWT"]
         data = ::Auth::JWTService.new.decode(token)

--- a/src/pipes/cors.cr
+++ b/src/pipes/cors.cr
@@ -1,0 +1,12 @@
+module Pipes
+  class CORS < Amber::Pipe::Base
+    def call(context)
+      if context.request.method == "OPTIONS" &&
+          !context.request.headers["Access-Control-Request-Headers"].includes? "content-type"
+        context.request.headers["Access-Control-Request-Headers"] += ",content-type"
+      end
+      
+      call_next(context)
+    end
+  end
+end

--- a/src/pipes/cors.cr
+++ b/src/pipes/cors.cr
@@ -2,10 +2,10 @@ module Pipes
   class CORS < Amber::Pipe::Base
     def call(context)
       if context.request.method == "OPTIONS" &&
-          !context.request.headers["Access-Control-Request-Headers"].includes? "content-type"
+         !context.request.headers["Access-Control-Request-Headers"].includes? "content-type"
         context.request.headers["Access-Control-Request-Headers"] += ",content-type"
       end
-      
+
       call_next(context)
     end
   end

--- a/src/pipes/cors.cr
+++ b/src/pipes/cors.cr
@@ -1,12 +1,22 @@
 module Pipes
-  class CORS < Amber::Pipe::Base
+  class CORS < Amber::Pipe::CORS
     def call(context)
-      if context.request.method == "OPTIONS" &&
-         !context.request.headers["Access-Control-Request-Headers"].includes? "content-type"
-        context.request.headers["Access-Control-Request-Headers"] += ",content-type"
+      if android?(context.request)
+        call_next(context)
+      else
+        if preflight?(context) && !content_type?(context.request)
+          context.request.headers[Amber::Pipe::Headers::REQUEST_HEADERS] += ",content-type"
+        end
+        super
       end
+    end
 
-      call_next(context)
+    private def android?(request) : Bool
+      request.headers["source"]? == "android"
+    end
+
+    private def content_type?(request) : Bool
+      request.headers[Amber::Pipe::Headers::REQUEST_HEADERS].includes? "content-type"
     end
   end
 end


### PR DESCRIPTION
- Fix : Dans le preflight, le content-type est retiré par la librairie si son contenu est classque comme multipart/form-data. S'il s'agit du preflight, forcer le content-type
- Regression : Ne plus faire utiliser le pipe CORS si les requêtes proviennent de l'application Android.
Pour cela, ajouter dans les headers ```{"source": "android"}```

![Sad](https://media.giphy.com/media/yoJC2Olx0ekMy2nX7W/giphy.gif)